### PR TITLE
Refactor: change signature of format()

### DIFF
--- a/src/Contracts/Currency.php
+++ b/src/Contracts/Currency.php
@@ -36,15 +36,11 @@ interface Currency
     /**
      * Use this method to represent monetary amounts as strings.
      *
-     * @todo: Pass something like CurrencyFormat with more flexible settings.
-     *
-     * @param string $decimalsSeparator
-     * @param string $thousandsSeparator
-     * @param int    $extraPrecision     use this parameter to represent monetary amounts below the currency precision
+     * @param CurrencyFormat $currencyFormat
      *
      * @return string
      */
-    public function format(string $decimalsSeparator = '.', string $thousandsSeparator = '', int $extraPrecision = 0): string;
+    public function format(CurrencyFormat $currencyFormat = null): string;
 
     /**
      * Use this method to compare currency values.

--- a/src/Contracts/CurrencyFormat.php
+++ b/src/Contracts/CurrencyFormat.php
@@ -4,9 +4,17 @@ namespace Adsmurai\Currency\Contracts;
 
 interface CurrencyFormat
 {
+    const DECORATION_NO_DECORATION = 0;
+    const DECORATION_SYMBOL = 1;
+    const DECORATION_ISO_CODE = 2;
+
     public function getDecimalsSeparator(): string;
 
     public function getThousandsSeparator(): string;
 
     public function getExtraPrecision(): int;
+
+    public function getPrecision();
+
+    public function getDecorationType(): int;
 }

--- a/src/Contracts/CurrencyFormat.php
+++ b/src/Contracts/CurrencyFormat.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Adsmurai\Currency\Contracts;
+
+interface CurrencyFormat
+{
+    public function getDecimalsSeparator(): string;
+
+    public function getThousandsSeparator(): string;
+
+    public function getExtraPrecision(): int;
+}

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -154,11 +154,10 @@ final class Currency implements CurrencyInterface
             $currencyFormat = new CurrencyFormat();
         }
 
-        $precision = $currencyFormat->getPrecision();
-        if (is_null($precision)) {
-            $precision = $this->currencyType->getNumFractionalDigits();
+        $nDecimals = $currencyFormat->getPrecision();
+        if (is_null($nDecimals)) {
+            $nDecimals = $this->currencyType->getNumFractionalDigits() + $currencyFormat->getExtraPrecision();
         }
-        $nDecimals = $precision + $currencyFormat->getExtraPrecision();
 
         $amount = Decimal::fromDecimal($this->amount, $nDecimals);
 

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -145,6 +145,7 @@ final class Currency implements CurrencyInterface
     }
 
     /**
+     * @todo Use method getDecorationType() when decorating the result
      * {@inheritdoc}
      */
     public function format(CurrencyFormatInterface $currencyFormat = null): string
@@ -153,7 +154,12 @@ final class Currency implements CurrencyInterface
             $currencyFormat = new CurrencyFormat();
         }
 
-        $nDecimals = $this->currencyType->getNumFractionalDigits() + $currencyFormat->getExtraPrecision();
+        $precision = $currencyFormat->getPrecision();
+        if (is_null($precision)) {
+            $precision = $this->currencyType->getNumFractionalDigits();
+        }
+        $nDecimals = $precision + $currencyFormat->getExtraPrecision();
+
         $amount = Decimal::fromDecimal($this->amount, $nDecimals);
 
         $number = ('' === $currencyFormat->getThousandsSeparator())

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -145,7 +145,6 @@ final class Currency implements CurrencyInterface
     }
 
     /**
-     * @todo Use method getDecorationType() when decorating the result
      * {@inheritdoc}
      */
     public function format(CurrencyFormatInterface $currencyFormat = null): string
@@ -170,9 +169,29 @@ final class Currency implements CurrencyInterface
                 $currencyFormat->getThousandsSeparator()
             );
 
-        return ($this->currencyType->getSymbolPlacement() === CurrencyType::BEFORE_PLACEMENT)
-            ? $this->currencyType->getSymbol().$number
-            : $number.$this->currencyType->getSymbol();
+        return $this->decorate($number, $currencyFormat);
+    }
+
+    /**
+     * @param string                  $number
+     * @param CurrencyFormatInterface $currencyFormat
+     *
+     * @return string
+     */
+    private function decorate(string $number, CurrencyFormatInterface $currencyFormat): string
+    {
+        switch ($currencyFormat->getDecorationType()) {
+            case CurrencyFormat::DECORATION_NO_DECORATION:
+                return $number;
+                break;
+            case CurrencyFormat::DECORATION_ISO_CODE:
+                return $number.$this->currencyType->getISOCode();
+                break;
+            default:
+                return ($this->currencyType->getSymbolPlacement() === CurrencyType::BEFORE_PLACEMENT)
+                    ? $this->currencyType->getSymbol().$number
+                    : $number.$this->currencyType->getSymbol();
+        }
     }
 
     /**

--- a/src/CurrencyFormat.php
+++ b/src/CurrencyFormat.php
@@ -18,12 +18,27 @@ class CurrencyFormat implements CurrencyFormatInterface
      * @var int
      */
     private $extraPrecision;
+    /**
+     * @var int
+     */
+    private $decorationType;
+    /**
+     * @var int
+     */
+    private $precision;
 
-    public function __construct(string $decimalsSeparator = '.', string $thousandsSeparator = '', int $extraPrecision = 0)
-    {
+    public function __construct(
+        string $decimalsSeparator = '.',
+        string $thousandsSeparator = '',
+        int $extraPrecision = 0,
+        int $decorationType = self::DECORATION_NO_DECORATION,
+        int $precision = null
+    ) {
         $this->decimalsSeparator = $decimalsSeparator;
         $this->thousandsSeparator = $thousandsSeparator;
         $this->extraPrecision = $extraPrecision;
+        $this->decorationType = $decorationType;
+        $this->precision = $precision;
     }
 
     /**
@@ -48,5 +63,21 @@ class CurrencyFormat implements CurrencyFormatInterface
     public function getExtraPrecision(): int
     {
         return $this->extraPrecision;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDecorationType(): int
+    {
+        return $this->decorationType;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPrecision()
+    {
+        return $this->precision;
     }
 }

--- a/src/CurrencyFormat.php
+++ b/src/CurrencyFormat.php
@@ -31,7 +31,7 @@ class CurrencyFormat implements CurrencyFormatInterface
         string $decimalsSeparator = '.',
         string $thousandsSeparator = '',
         int $extraPrecision = 0,
-        int $decorationType = self::DECORATION_NO_DECORATION,
+        int $decorationType = self::DECORATION_SYMBOL,
         int $precision = null
     ) {
         $this->decimalsSeparator = $decimalsSeparator;

--- a/src/CurrencyFormat.php
+++ b/src/CurrencyFormat.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Adsmurai\Currency;
+
+use Adsmurai\Currency\Contracts\CurrencyFormat as CurrencyFormatInterface;
+
+class CurrencyFormat implements CurrencyFormatInterface
+{
+    /**
+     * @var string
+     */
+    private $decimalsSeparator;
+    /**
+     * @var string
+     */
+    private $thousandsSeparator;
+    /**
+     * @var int
+     */
+    private $extraPrecision;
+
+    public function __construct(string $decimalsSeparator = '.', string $thousandsSeparator = '', int $extraPrecision = 0)
+    {
+        $this->decimalsSeparator = $decimalsSeparator;
+        $this->thousandsSeparator = $thousandsSeparator;
+        $this->extraPrecision = $extraPrecision;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDecimalsSeparator(): string
+    {
+        return $this->decimalsSeparator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getThousandsSeparator(): string
+    {
+        return $this->thousandsSeparator;
+    }
+
+    /**
+     * @return int
+     */
+    public function getExtraPrecision(): int
+    {
+        return $this->extraPrecision;
+    }
+}

--- a/tests/Currency/FormatTests.php
+++ b/tests/Currency/FormatTests.php
@@ -6,6 +6,7 @@ namespace Adsmurai\Currency\Tests\Currency;
 
 use Adsmurai\Currency\Currency;
 use Adsmurai\Currency\Contracts\CurrencyType;
+use Adsmurai\Currency\CurrencyFormat;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -36,7 +37,8 @@ class formatTests extends TestCase
         string $formattedCurrency
     ) {
         $currency = Currency::fromString($amount, $currencyType);
-        $this->assertEquals($formattedCurrency, $currency->format($decimalsSeparator, $thousandsSeparator));
+        $currencyFormat = new CurrencyFormat($decimalsSeparator, $thousandsSeparator);
+        $this->assertEquals($formattedCurrency, $currency->format($currencyFormat));
     }
 
     /**
@@ -50,7 +52,8 @@ class formatTests extends TestCase
         string $formattedCurrency
     ) {
         $currency = Currency::fromString($amount, $currencyType);
-        $this->assertEquals($formattedCurrency, $currency->format('.', '', $extraPrecision));
+        $currencyFormat = new CurrencyFormat('.', '', $extraPrecision);
+        $this->assertEquals($formattedCurrency, $currency->format($currencyFormat));
     }
 
     public function simpleParamsProvider(): array

--- a/tests/Currency/FormatTests.php
+++ b/tests/Currency/FormatTests.php
@@ -56,6 +56,21 @@ class formatTests extends TestCase
         $this->assertEquals($formattedCurrency, $currency->format($currencyFormat));
     }
 
+    /**
+     * @dataProvider precisionParamsProvider
+     * @covers \Adsmurai\Currency\Currency::format
+     */
+    public function test_format_with_custom_precision(
+        string $amount,
+        CurrencyType $currencyType,
+        int $extraPrecision,
+        string $formattedCurrency
+    ) {
+        $currency = Currency::fromString($amount, $currencyType);
+        $currencyFormat = new CurrencyFormat('.', '', 0, 0, $extraPrecision);
+        $this->assertEquals($formattedCurrency, $currency->format($currencyFormat));
+    }
+
     public function simpleParamsProvider(): array
     {
         return [
@@ -137,6 +152,31 @@ class formatTests extends TestCase
             ['100', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), 2, '$100.00000'],
             ['0.01', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), 2, '$0.01000'],
             ['12345678.50', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), 2, '$12345678.50000'],
+        ];
+    }
+
+    public function precisionParamsProvider(): array
+    {
+        return [
+            ['34.76', $this->getNDecimalDigitsCurrencyType(), 2, '34.76€'],
+            ['100', $this->getNDecimalDigitsCurrencyType(), 2, '100.00€'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(), 2, '0.01€'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(), 2, '12345678.50€'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3), 2, '34.76€'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3), 2, '100.00€'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3), 2, '0.01€'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3), 2, '12345678.50€'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3, '$'), 2, '34.76$'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3, '$'), 2, '100.00$'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3, '$'), 2, '0.01$'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3, '$'), 2, '12345678.50$'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), 2, '$34.76'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), 2, '$100.00'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), 2, '$0.01'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), 2, '$12345678.50'],
         ];
     }
 

--- a/tests/Currency/FormatTests.php
+++ b/tests/Currency/FormatTests.php
@@ -67,7 +67,7 @@ class formatTests extends TestCase
         string $formattedCurrency
     ) {
         $currency = Currency::fromString($amount, $currencyType);
-        $currencyFormat = new CurrencyFormat('.', '', 0, 0, $extraPrecision);
+        $currencyFormat = new CurrencyFormat('.', '', 3, 0, $extraPrecision);
         $this->assertEquals($formattedCurrency, $currency->format($currencyFormat));
     }
 

--- a/tests/Currency/FormatTests.php
+++ b/tests/Currency/FormatTests.php
@@ -67,7 +67,36 @@ class formatTests extends TestCase
         string $formattedCurrency
     ) {
         $currency = Currency::fromString($amount, $currencyType);
-        $currencyFormat = new CurrencyFormat('.', '', 3, 0, $extraPrecision);
+        $currencyFormat = new CurrencyFormat('.', '', 3, 1, $extraPrecision);
+        $this->assertEquals($formattedCurrency, $currency->format($currencyFormat));
+    }
+
+    /**
+     * @dataProvider noDecorationParamsProvider
+     * @covers \Adsmurai\Currency\Currency::format
+     */
+    public function test_format_with_no_decoration(
+        string $amount,
+        CurrencyType $currencyType,
+        string $formattedCurrency
+    ) {
+        //$this->markTestSkipped();
+        $currency = Currency::fromString($amount, $currencyType);
+        $currencyFormat = new CurrencyFormat('.', '', 0, CurrencyFormat::DECORATION_NO_DECORATION);
+        $this->assertEquals($formattedCurrency, $currency->format($currencyFormat));
+    }
+
+    /**
+     * @dataProvider isoCodeDecorationParamsProvider
+     * @covers \Adsmurai\Currency\Currency::format
+     */
+    public function test_format_with_decoration_iso_code(
+        string $amount,
+        CurrencyType $currencyType,
+        string $formattedCurrency
+    ) {
+        $currency = Currency::fromString($amount, $currencyType);
+        $currencyFormat = new CurrencyFormat('.', '', 0, CurrencyFormat::DECORATION_ISO_CODE);
         $this->assertEquals($formattedCurrency, $currency->format($currencyFormat));
     }
 
@@ -180,10 +209,79 @@ class formatTests extends TestCase
         ];
     }
 
+    public function noDecorationParamsProvider(): array
+    {
+        return [
+            ['34.76', $this->getNDecimalDigitsCurrencyType(), '34.76'],
+            ['100', $this->getNDecimalDigitsCurrencyType(), '100.00'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(), '0.01'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(), '12345678.50'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3), '34.760'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3), '100.000'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3), '0.010'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3), '12345678.500'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3, '$'), '34.760'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3, '$'), '100.000'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3, '$'), '0.010'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3, '$'), '12345678.500'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), '34.760'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), '100.000'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), '0.010'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT), '12345678.500'],
+
+            ['34.761', $this->getNDecimalDigitsCurrencyType(), '34.76'],
+            ['34.766', $this->getNDecimalDigitsCurrencyType(), '34.77'],
+            ['100.002', $this->getNDecimalDigitsCurrencyType(), '100.00'],
+            ['100.008', $this->getNDecimalDigitsCurrencyType(), '100.01'],
+            ['0.014', $this->getNDecimalDigitsCurrencyType(), '0.01'],
+            ['0.017', $this->getNDecimalDigitsCurrencyType(), '0.02'],
+            ['12345678.503', $this->getNDecimalDigitsCurrencyType(), '12345678.50'],
+            ['12345678.509', $this->getNDecimalDigitsCurrencyType(), '12345678.51'],
+        ];
+    }
+
+    public function isoCodeDecorationParamsProvider(): array
+    {
+        return [
+            ['34.76', $this->getNDecimalDigitsCurrencyType(), '34.76EUR'],
+            ['100', $this->getNDecimalDigitsCurrencyType(), '100.00EUR'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(), '0.01EUR'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(), '12345678.50EUR'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3), '34.760EUR'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3), '100.000EUR'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3), '0.010EUR'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3), '12345678.500EUR'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::AFTER_PLACEMENT, 'USD'), '34.760USD'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::AFTER_PLACEMENT, 'USD'), '100.000USD'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::AFTER_PLACEMENT, 'USD'), '0.010USD'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::AFTER_PLACEMENT, 'USD'), '12345678.500USD'],
+
+            ['34.76', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT, 'USD'), '34.760USD'],
+            ['100', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT, 'USD'), '100.000USD'],
+            ['0.01', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT, 'USD'), '0.010USD'],
+            ['12345678.50', $this->getNDecimalDigitsCurrencyType(3, '$', CurrencyType::BEFORE_PLACEMENT, 'USD'), '12345678.500USD'],
+
+            ['34.761', $this->getNDecimalDigitsCurrencyType(), '34.76EUR'],
+            ['34.766', $this->getNDecimalDigitsCurrencyType(), '34.77EUR'],
+            ['100.002', $this->getNDecimalDigitsCurrencyType(), '100.00EUR'],
+            ['100.008', $this->getNDecimalDigitsCurrencyType(), '100.01EUR'],
+            ['0.014', $this->getNDecimalDigitsCurrencyType(), '0.01EUR'],
+            ['0.017', $this->getNDecimalDigitsCurrencyType(), '0.02EUR'],
+            ['12345678.503', $this->getNDecimalDigitsCurrencyType(), '12345678.50EUR'],
+            ['12345678.509', $this->getNDecimalDigitsCurrencyType(), '12345678.51EUR'],
+        ];
+    }
+
     private static function getNDecimalDigitsCurrencyType(
         int $n = 2,
         string $symbol = '€',
-        int $symbolPlacement = CurrencyType::AFTER_PLACEMENT
+        int $symbolPlacement = CurrencyType::AFTER_PLACEMENT,
+        string $isoCode = 'EUR'
     ): CurrencyType {
         /** @var CurrencyType|MockInterface $currencyType */
         $currencyType = \Mockery::mock(CurrencyType::class);
@@ -192,7 +290,7 @@ class formatTests extends TestCase
             ->shouldReceive('getNumFractionalDigits')->andReturn($n)
             ->shouldReceive('getSymbol')->andReturn($symbol)
             ->shouldReceive('getSymbolPlacement')->andReturn($symbolPlacement)
-            ->shouldReceive('getISOCode')->andReturn('EUR');
+            ->shouldReceive('getISOCode')->andReturn($isoCode);
 
         return $currencyType;
     }


### PR DESCRIPTION
Change signature of format() method to accept CurrencyFormat interface.

This is the first step to be able to improve the format() method as requested on #1 

This is a breaking change.