### PR TITLE
Improve PHP7.2 CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: php
 
-php:
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm
-
 matrix:
+  include:
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: hhvm
+      env:
+        - HHVMPHP7="yes"
+    - php: hhvm
+      env:
+        - HHVMPHP7="no"
+
   allow_failures:
     - php: 7.2
     - php: hhvm
@@ -16,6 +21,9 @@ install:
    - mkdir -p build/logs
    - curl -sS https://getcomposer.org/installer | php -- --install-dir=./build/bin
    - php ./build/bin/composer.phar install
+
+before_script:
+  - "if [[ ${HHVMPHP7} == 'yes' ]]; then echo 'hhvm.php7.all=1' >> /etc/hhvm/php.ini; fi"
 
 script:
    - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
         - HHVMPHP7="no"
 
   allow_failures:
-    - php: 7.2
     - php: hhvm
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^0.9",
-        "phpunit/phpunit": "^6.1",
-        "friendsofphp/php-cs-fixer": "^2.3"
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The original intent was to improve HHVM CI support, but Travis-CI is still using HHVM 3.18,
and this library requires HHVM 3.21.

In the meantime, we've fixed the support for PHP7.2 in the Travis-CI pipeline.