### PR TITLE
Fix Rial Omani fractional digits

### DIFF
--- a/src/Data/CurrencyTypes.php
+++ b/src/Data/CurrencyTypes.php
@@ -331,7 +331,7 @@ return [
         'symbolPlacement' => Currency::AFTER_PLACEMENT,
     ],
     'OMR' => [
-        'numFractionalDigits' => 2,
+        'numFractionalDigits' => 3,
         'symbol' => 'ر.ع.',
         'symbolPlacement' => Currency::AFTER_PLACEMENT,
     ],


### PR DESCRIPTION
This fixes the mismatch of fractional digits between Adsmurai currency library and moneyphp.

https://github.com/moneyphp/money/blob/master/resources/currency.php (Search for "OMR")