### PR TITLE
Fc 9274 remove deprecated dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
-FROM ubuntu:latest
+FROM php:8.4-cli
 
-ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    curl \
+    libxml2-dev \
+    libzip-dev \
+    libonig-dev \
+    unzip
 
-RUN apt-get update
-RUN apt-get install curl php php-xml php-bcmath php-mbstring php-xdebug php-zip -y
+RUN docker-php-ext-install \
+    xml \
+    bcmath \
+    mbstring \
+    zip
+
+RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 RUN curl -sS https://getcomposer.org/installer | php \
-		&& mv composer.phar /usr/local/bin/ \
-		&& ln -s /usr/local/bin/composer.phar /usr/local/bin/composer
+    && mv composer.phar /usr/local/bin/composer \
+    && chmod +x /usr/local/bin/composer
 
-COPY . /app
 WORKDIR /app
-
-RUN composer install

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.1",
-        "litipk/php-bignumbers": "^0.8"
+        "brick/math": "^0.12"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=8.1",
-        "brick/math": "^0.12"
+        "php": ">=8.4",
+        "brick/math": "^0.14"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Contracts/Money.php
+++ b/src/Contracts/Money.php
@@ -2,7 +2,7 @@
 
 namespace Adsmurai\Currency\Contracts;
 
-use Litipk\BigNumbers\Decimal;
+use Brick\Math\BigDecimal;
 
 interface Money
 {
@@ -14,7 +14,7 @@ interface Money
      * This method returns the monetary amount as a string representing a decimal number. Its meant to be used in
      * fixed precision mathematical operations, like the ones that can be done with libraries like BCMath.
      */
-    public function getAmountAsDecimal(): Decimal;
+    public function getAmountAsDecimal(): BigDecimal;
 
     /**
      * WARNING: This method is not meant to be used in currency formatting code nor currency representation code.

--- a/src/Contracts/MoneyFactory.php
+++ b/src/Contracts/MoneyFactory.php
@@ -2,7 +2,7 @@
 
 namespace Adsmurai\Currency\Contracts;
 
-use Litipk\BigNumbers\Decimal;
+use Brick\Math\BigDecimal;
 
 interface MoneyFactory
 {
@@ -12,5 +12,5 @@ interface MoneyFactory
 
     public function buildFromString(string $amount): Money;
 
-    public function buildFromDecimal(Decimal $amount): Money;
+    public function buildFromDecimal(BigDecimal $amount): Money;
 }

--- a/src/Money.php
+++ b/src/Money.php
@@ -7,10 +7,9 @@ namespace Adsmurai\Currency;
 use Adsmurai\Currency\Contracts\Money as MoneyContract;
 use Adsmurai\Currency\Contracts\MoneyFormat as MoneyFormatInterface;
 use Adsmurai\Currency\Contracts\Currency as CurrencyContract;
+use Brick\Math\BigDecimal;
+use Brick\Math\RoundingMode;
 use InvalidArgumentException;
-use Litipk\BigNumbers\Decimal;
-use Litipk\BigNumbers\Errors\InfiniteInputError;
-use Litipk\BigNumbers\Errors\NaNInputError;
 
 final class Money implements MoneyContract
 {
@@ -18,30 +17,33 @@ final class Money implements MoneyContract
     public const SIMPLE_CURRENCY_PATTERN = '/^'.self::DECIMAL_NUMBER_REGEXP.'$/x';
     public const INNER_FRACTIONAL_DIGITS = 8;
 
-    private function __construct(private readonly Decimal $amount, private readonly CurrencyContract $currency)
+    private function __construct(private readonly BigDecimal $amount, private readonly CurrencyContract $currency)
     {
     }
 
     public static function fromFloat(float $amount, CurrencyContract $currency): Money
     {
-        try {
-            return new self(
-                Decimal::fromFloat($amount, self::INNER_FRACTIONAL_DIGITS),
-                $currency
-            );
-        } catch (InfiniteInputError $e) {
-            throw new InvalidArgumentException('Currency amounts must be finite', 0, $e);
-        } catch (NaNInputError $e) {
-            throw new InvalidArgumentException('Currency amounts must be numbers', 0, $e);
+        if (!is_finite($amount)) {
+            throw new InvalidArgumentException('Currency amounts must be finite');
         }
+
+        if (is_nan($amount)) {
+            throw new InvalidArgumentException('Currency amounts must be numbers');
+        }
+
+        return new self(
+            BigDecimal::of($amount)->toScale(self::INNER_FRACTIONAL_DIGITS, RoundingMode::HALF_UP),
+            $currency
+        );
     }
 
     public static function fromFractionalUnits(int $amount, CurrencyContract $currency): Money
     {
-        $decimalAmount = Decimal::fromInteger($amount)
-            ->div(
-                Decimal::fromInteger(10 ** $currency->getNumFractionalDigits()),
-                self::INNER_FRACTIONAL_DIGITS
+        $decimalAmount = BigDecimal::of($amount)
+            ->dividedBy(
+                BigDecimal::of(10 ** $currency->getNumFractionalDigits()),
+                self::INNER_FRACTIONAL_DIGITS,
+                RoundingMode::HALF_UP
             );
 
         return new self($decimalAmount, $currency);
@@ -55,14 +57,14 @@ final class Money implements MoneyContract
         );
     }
 
-    private static function extractNumericAmount(string $amount, CurrencyContract $currency): Decimal
+    private static function extractNumericAmount(string $amount, CurrencyContract $currency): BigDecimal
     {
         if (
             1 === \preg_match(self::SIMPLE_CURRENCY_PATTERN, $amount, $matches) ||
             1 === \preg_match(self::getAmountPlusIsoCodePattern($currency), $amount, $matches) ||
             1 === \preg_match(self::getAmountPlusSymbolPattern($currency), $amount, $matches)
         ) {
-            return Decimal::fromString($matches['amount'], self::INNER_FRACTIONAL_DIGITS);
+            return BigDecimal::of($matches['amount'])->toScale(self::INNER_FRACTIONAL_DIGITS, RoundingMode::HALF_UP);
         }
 
         throw new InvalidArgumentException('Invalid currency value');
@@ -82,10 +84,10 @@ final class Money implements MoneyContract
             : '/^'.self::DECIMAL_NUMBER_REGEXP.'\s*'.$escapedSymbol.'$/x';
     }
 
-    public static function fromDecimal(Decimal $amount, CurrencyContract $currency): Money
+    public static function fromDecimal(BigDecimal $amount, CurrencyContract $currency): Money
     {
         return new self(
-            Decimal::fromDecimal($amount, self::INNER_FRACTIONAL_DIGITS),
+            $amount->toScale(self::INNER_FRACTIONAL_DIGITS, RoundingMode::HALF_UP),
             $currency
         );
     }
@@ -98,7 +100,7 @@ final class Money implements MoneyContract
     /**
      * {@inheritdoc}
      */
-    public function getAmountAsDecimal(): Decimal
+    public function getAmountAsDecimal(): BigDecimal
     {
         return $this->amount;
     }
@@ -109,11 +111,11 @@ final class Money implements MoneyContract
     public function getAmountAsFractionalUnits(): int
     {
         return $this->amount
-            ->mul(
-                Decimal::fromInteger(10 ** $this->currency->getNumFractionalDigits()),
-                self::INNER_FRACTIONAL_DIGITS
+            ->multipliedBy(
+                BigDecimal::of(10 ** $this->currency->getNumFractionalDigits())
             )
-            ->asInteger();
+            ->toScale(self::INNER_FRACTIONAL_DIGITS, RoundingMode::HALF_UP)
+            ->toInt();
     }
 
     /**
@@ -130,12 +132,12 @@ final class Money implements MoneyContract
             $nDecimals = $this->currency->getNumFractionalDigits() + $currencyFormat->getExtraPrecision();
         }
 
-        $amount = Decimal::fromDecimal($this->amount, $nDecimals);
+        $amount = $this->amount->toScale($nDecimals, RoundingMode::HALF_UP);
 
         $number = ('' === $currencyFormat->getThousandsSeparator())
             ? \str_replace('.', $currencyFormat->getDecimalsSeparator(), $amount->__toString())  // This is safer!
             : \number_format(
-                $amount->asFloat(),
+                $amount->toFloat(),
                 $nDecimals,
                 $currencyFormat->getDecimalsSeparator(),
                 $currencyFormat->getThousandsSeparator()
@@ -165,7 +167,7 @@ final class Money implements MoneyContract
     public function equals(MoneyContract $currency): bool
     {
         return $currency === $this || (
-            $this->amount->equals($currency->getAmountAsDecimal()) &&
+            $this->amount->isEqualTo($currency->getAmountAsDecimal()) &&
                 $this->currency->equals($currency->getCurrency())
         );
     }

--- a/src/Money.php
+++ b/src/Money.php
@@ -23,7 +23,7 @@ final class Money implements MoneyContract
 
     public static function fromFloat(float $amount, CurrencyContract $currency): Money
     {
-        if (!is_finite($amount)) {
+        if (!is_finite($amount) && !is_nan($amount)) {
             throw new InvalidArgumentException('Currency amounts must be finite');
         }
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -114,7 +114,7 @@ final class Money implements MoneyContract
             ->multipliedBy(
                 BigDecimal::of(10 ** $this->currency->getNumFractionalDigits())
             )
-            ->toScale(self::INNER_FRACTIONAL_DIGITS, RoundingMode::HALF_UP)
+            ->toScale(0, RoundingMode::DOWN)
             ->toInt();
     }
 

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -7,7 +7,7 @@ namespace Adsmurai\Currency;
 use Adsmurai\Currency\Contracts\Money as MoneyContract;
 use Adsmurai\Currency\Contracts\MoneyFactory as MoneyFactoryContract;
 use Adsmurai\Currency\Contracts\Currency as CurrencyContract;
-use Litipk\BigNumbers\Decimal;
+use Brick\Math\BigDecimal;
 
 final class MoneyFactory implements MoneyFactoryContract
 {
@@ -30,7 +30,7 @@ final class MoneyFactory implements MoneyFactoryContract
         return Money::fromString($amount, $this->currency);
     }
 
-    public function buildFromDecimal(Decimal $amount): MoneyContract
+    public function buildFromDecimal(BigDecimal $amount): MoneyContract
     {
         return Money::fromDecimal($amount, $this->currency);
     }

--- a/tests/Currency/BasicGetterTests.php
+++ b/tests/Currency/BasicGetterTests.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Adsmurai\Currency\Tests\Currency;
 
 use Adsmurai\Currency\Money;
-use Litipk\BigNumbers\Decimal;
+use Brick\Math\BigDecimal;
 use PHPUnit\Framework\TestCase;
 
 class BasicGetterTests extends TestCase
@@ -16,14 +16,12 @@ class BasicGetterTests extends TestCase
      */
     public function test_basic_getters(): void
     {
-        // @todo: Improve the test to decouple from Decimal. It requires refactoring Decimal.
-
-        $amount = Decimal::fromString('34.56');
+        $amount = BigDecimal::of('34.56');
         $currencyType = CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType();
 
         $currency = Money::fromDecimal($amount, $currencyType);
 
-        $this->assertSame($amount, $currency->getAmountAsDecimal());
+        $this->assertTrue($amount->isEqualTo($currency->getAmountAsDecimal()));
         $this->assertSame($currencyType, $currency->getCurrency());
     }
 }

--- a/tests/Currency/EqualsTests.php
+++ b/tests/Currency/EqualsTests.php
@@ -7,22 +7,19 @@ namespace Adsmurai\Currency\Tests\Currency;
 use Adsmurai\Currency\Contracts\Money as CurrencyInterface;
 use Adsmurai\Currency\Money;
 use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class EqualsTests extends TestCase
 {
-    /**
-     * @dataProvider equalCurrenciesProvider
-     */
+    #[DataProvider('equalCurrenciesProvider')]
     public function test_equality(CurrencyInterface $c1, CurrencyInterface $c2): void
     {
         $this->assertTrue($c1->equals($c2));
         $this->assertTrue($c2->equals($c1));
     }
 
-    /**
-     * @dataProvider unequalCurrenciesProvider
-     */
+    #[DataProvider('unequalCurrenciesProvider')]
     public function test_inequality(CurrencyInterface $c1, CurrencyInterface $c2): void
     {
         $this->assertFalse($c1->equals($c2));

--- a/tests/Currency/EqualsTests.php
+++ b/tests/Currency/EqualsTests.php
@@ -6,7 +6,7 @@ namespace Adsmurai\Currency\Tests\Currency;
 
 use Adsmurai\Currency\Contracts\Money as CurrencyInterface;
 use Adsmurai\Currency\Money;
-use Litipk\BigNumbers\Decimal;
+use Brick\Math\BigDecimal;
 use PHPUnit\Framework\TestCase;
 
 class EqualsTests extends TestCase
@@ -46,7 +46,7 @@ class EqualsTests extends TestCase
         yield [
             Money::fromString('34.75', CurrencyTypeMocks::getComparableTwoDecimalDigitsCurrencyType()),
             Money::fromDecimal(
-                Decimal::fromString('34.75'),
+                BigDecimal::of('34.75'),
                 CurrencyTypeMocks::getComparableTwoDecimalDigitsCurrencyType()
             ),
         ];
@@ -69,7 +69,7 @@ class EqualsTests extends TestCase
         yield [
             Money::fromString('34.75', CurrencyTypeMocks::getComparableTwoDecimalDigitsCurrencyType()),
             Money::fromDecimal(
-                Decimal::fromString('34.76'),
+                BigDecimal::of('34.76'),
                 CurrencyTypeMocks::getComparableTwoDecimalDigitsCurrencyType()
             ),
         ];
@@ -91,7 +91,7 @@ class EqualsTests extends TestCase
         yield [
             Money::fromString('34.75', CurrencyTypeMocks::getComparableTwoDecimalDigitsCurrencyType(false)),
             Money::fromDecimal(
-                Decimal::fromString('34.75'),
+                BigDecimal::of('34.75'),
                 CurrencyTypeMocks::getComparableTwoDecimalDigitsCurrencyType(false)
             ),
         ];

--- a/tests/Currency/FormatTests.php
+++ b/tests/Currency/FormatTests.php
@@ -8,15 +8,16 @@ use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\Money;
 use Adsmurai\Currency\MoneyFormat;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FormatTests extends TestCase
 {
     /**
-     * @dataProvider simpleParamsProvider
-     * @covers       \Adsmurai\Currency\Money::format
-     * @covers       \Adsmurai\Currency\Money::decorate
+     * @covers \Adsmurai\Currency\Money::format
+     * @covers \Adsmurai\Currency\Money::decorate
      */
+    #[DataProvider('simpleParamsProvider')]
     public function test_format_without_custom_parameters(
         string $amount,
         Currency $currencyType,
@@ -27,10 +28,10 @@ class FormatTests extends TestCase
     }
 
     /**
-     * @dataProvider customizedParamsProvider
-     * @covers       \Adsmurai\Currency\Money::format
-     * @covers       \Adsmurai\Currency\Money::decorate
+     * @covers \Adsmurai\Currency\Money::format
+     * @covers \Adsmurai\Currency\Money::decorate
      */
+    #[DataProvider('customizedParamsProvider')]
     public function test_format_with_custom_separators(
         string $amount,
         Currency $currencyType,
@@ -44,10 +45,10 @@ class FormatTests extends TestCase
     }
 
     /**
-     * @dataProvider extraPrecisionParamsProvider
-     * @covers       \Adsmurai\Currency\Money::format
-     * @covers       \Adsmurai\Currency\Money::decorate
+     * @covers \Adsmurai\Currency\Money::format
+     * @covers \Adsmurai\Currency\Money::decorate
      */
+    #[DataProvider('extraPrecisionParamsProvider')]
     public function test_format_with_extra_precision(
         string $amount,
         Currency $currencyType,
@@ -60,10 +61,10 @@ class FormatTests extends TestCase
     }
 
     /**
-     * @dataProvider precisionParamsProvider
-     * @covers       \Adsmurai\Currency\Money::format
-     * @covers       \Adsmurai\Currency\Money::decorate
+     * @covers \Adsmurai\Currency\Money::format
+     * @covers \Adsmurai\Currency\Money::decorate
      */
+    #[DataProvider('precisionParamsProvider')]
     public function test_format_with_custom_precision(
         string $amount,
         Currency $currencyType,
@@ -76,10 +77,10 @@ class FormatTests extends TestCase
     }
 
     /**
-     * @dataProvider noDecorationParamsProvider
-     * @covers       \Adsmurai\Currency\Money::format
-     * @covers       \Adsmurai\Currency\Money::decorate
+     * @covers \Adsmurai\Currency\Money::format
+     * @covers \Adsmurai\Currency\Money::decorate
      */
+    #[DataProvider('noDecorationParamsProvider')]
     public function test_format_with_no_decoration(
         string $amount,
         Currency $currencyType,
@@ -95,10 +96,10 @@ class FormatTests extends TestCase
     }
 
     /**
-     * @dataProvider isoCodeDecorationParamsProvider
-     * @covers       \Adsmurai\Currency\Money::format
-     * @covers       \Adsmurai\Currency\Money::decorate
+     * @covers \Adsmurai\Currency\Money::format
+     * @covers \Adsmurai\Currency\Money::decorate
      */
+    #[DataProvider('isoCodeDecorationParamsProvider')]
     public function test_format_with_decoration_iso_code(
         string $amount,
         Currency $currencyType,
@@ -114,10 +115,10 @@ class FormatTests extends TestCase
     }
 
     /**
-     * @dataProvider spaceDecorationParamsProvider
-     * @covers       \Adsmurai\Currency\Money::format
-     * @covers       \Adsmurai\Currency\Money::decorate
+     * @covers \Adsmurai\Currency\Money::format
+     * @covers \Adsmurai\Currency\Money::decorate
      */
+    #[DataProvider('spaceDecorationParamsProvider')]
     public function test_format_with_separator(
         string $amount,
         Currency $currencyType,

--- a/tests/Currency/FromDecimalTests.php
+++ b/tests/Currency/FromDecimalTests.php
@@ -8,15 +8,16 @@ use Adsmurai\Currency\Contracts\Money as CurrencyInterface;
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\Money;
 use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FromDecimalTests extends TestCase
 {
     /**
-     * @dataProvider validParamsProvider
-     * @covers       \Adsmurai\Currency\Money::fromDecimal
-     * @covers       \Adsmurai\Currency\Money::__construct
+     * @covers \Adsmurai\Currency\Money::fromDecimal
+     * @covers \Adsmurai\Currency\Money::__construct
      */
+    #[DataProvider('validParamsProvider')]
     public function test_with_valid_params(BigDecimal $amount, Currency $currencyType): void
     {
         $currency = Money::fromDecimal($amount, $currencyType);

--- a/tests/Currency/FromDecimalTests.php
+++ b/tests/Currency/FromDecimalTests.php
@@ -7,7 +7,7 @@ namespace Adsmurai\Currency\Tests\Currency;
 use Adsmurai\Currency\Contracts\Money as CurrencyInterface;
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\Money;
-use Litipk\BigNumbers\Decimal;
+use Brick\Math\BigDecimal;
 use PHPUnit\Framework\TestCase;
 
 class FromDecimalTests extends TestCase
@@ -17,7 +17,7 @@ class FromDecimalTests extends TestCase
      * @covers       \Adsmurai\Currency\Money::fromDecimal
      * @covers       \Adsmurai\Currency\Money::__construct
      */
-    public function test_with_valid_params(Decimal $amount, Currency $currencyType): void
+    public function test_with_valid_params(BigDecimal $amount, Currency $currencyType): void
     {
         $currency = Money::fromDecimal($amount, $currencyType);
 
@@ -27,13 +27,13 @@ class FromDecimalTests extends TestCase
 
     public static function validParamsProvider(): \Iterator
     {
-        yield [Decimal::fromString('34.76'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
-        yield [Decimal::fromString('100'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
-        yield [Decimal::fromString('0.01'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
-        yield [Decimal::fromString('12345678.50'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
-        yield [Decimal::fromString('-34.76'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
-        yield [Decimal::fromString('-100'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
-        yield [Decimal::fromString('-0.01'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
-        yield [Decimal::fromString('-12345678.50'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
+        yield [BigDecimal::of('34.76'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
+        yield [BigDecimal::of('100'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
+        yield [BigDecimal::of('0.01'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
+        yield [BigDecimal::of('12345678.50'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
+        yield [BigDecimal::of('-34.76'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
+        yield [BigDecimal::of('-100'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
+        yield [BigDecimal::of('-0.01'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
+        yield [BigDecimal::of('-12345678.50'), CurrencyTypeMocks::getTwoDecimalDigitsCurrencyType()];
     }
 }

--- a/tests/Currency/FromFloatTests.php
+++ b/tests/Currency/FromFloatTests.php
@@ -7,15 +7,16 @@ namespace Adsmurai\Currency\Tests\Currency;
 use Adsmurai\Currency\Contracts\Money as CurrencyInterface;
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\Money;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FromFloatTests extends TestCase
 {
     /**
-     * @dataProvider validParamsProvider
-     * @covers       \Adsmurai\Currency\Money::fromFloat
-     * @covers       \Adsmurai\Currency\Money::__construct
+     * @covers \Adsmurai\Currency\Money::fromFloat
+     * @covers \Adsmurai\Currency\Money::__construct
      */
+    #[DataProvider('validParamsProvider')]
     public function test_with_valid_params(float $amount, Currency $currencyType): void
     {
         $currency = Money::fromFloat($amount, $currencyType);
@@ -25,10 +26,10 @@ class FromFloatTests extends TestCase
     }
 
     /**
-     * @dataProvider infiniteParamsProvider
-     * @covers       \Adsmurai\Currency\Money::fromFloat
-     * @covers       \Adsmurai\Currency\Money::__construct
+     * @covers \Adsmurai\Currency\Money::fromFloat
+     * @covers \Adsmurai\Currency\Money::__construct
      */
+    #[DataProvider('infiniteParamsProvider')]
     public function test_with_infinite_amounts(float $amount, Currency $currencyType): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Currency/FromFractionalUnitsTests.php
+++ b/tests/Currency/FromFractionalUnitsTests.php
@@ -7,15 +7,16 @@ namespace Adsmurai\Currency\Tests\Currency;
 use Adsmurai\Currency\Contracts\Money as CurrencyInterface;
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\Money;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FromFractionalUnitsTests extends TestCase
 {
     /**
-     * @dataProvider validParamsProvider
-     * @covers       \Adsmurai\Currency\Money::fromFractionalUnits
-     * @covers       \Adsmurai\Currency\Money::__construct
+     * @covers \Adsmurai\Currency\Money::fromFractionalUnits
+     * @covers \Adsmurai\Currency\Money::__construct
      */
+    #[DataProvider('validParamsProvider')]
     public function test_with_valid_params(int $amount, Currency $currencyType): void
     {
         $currency = Money::fromFractionalUnits($amount, $currencyType);

--- a/tests/Currency/FromStringTests.php
+++ b/tests/Currency/FromStringTests.php
@@ -7,18 +7,19 @@ namespace Adsmurai\Currency\Tests\Currency;
 use Adsmurai\Currency\Contracts\Money as CurrencyInterface;
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\Money;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FromStringTests extends TestCase
 {
     /**
-     * @dataProvider validParamsProvider
-     * @covers       \Adsmurai\Currency\Money::fromString
-     * @covers       \Adsmurai\Currency\Money::extractNumericAmount
-     * @covers       \Adsmurai\Currency\Money::getAmountPlusIsoCodePattern
-     * @covers       \Adsmurai\Currency\Money::getAmountPlusSymbolPattern
-     * @covers       \Adsmurai\Currency\Money::__construct
+     * @covers \Adsmurai\Currency\Money::fromString
+     * @covers \Adsmurai\Currency\Money::extractNumericAmount
+     * @covers \Adsmurai\Currency\Money::getAmountPlusIsoCodePattern
+     * @covers \Adsmurai\Currency\Money::getAmountPlusSymbolPattern
+     * @covers \Adsmurai\Currency\Money::__construct
      */
+    #[DataProvider('validParamsProvider')]
     public function test_with_valid_params(string $amount, Currency $currencyType): void
     {
         $currency = Money::fromString($amount, $currencyType);
@@ -83,12 +84,12 @@ class FromStringTests extends TestCase
     }
 
     /**
-     * @dataProvider invalidParamsProvider
-     * @covers       \Adsmurai\Currency\Money::fromString
-     * @covers       \Adsmurai\Currency\Money::extractNumericAmount
-     * @covers       \Adsmurai\Currency\Money::getAmountPlusIsoCodePattern
-     * @covers       \Adsmurai\Currency\Money::getAmountPlusSymbolPattern
+     * @covers \Adsmurai\Currency\Money::fromString
+     * @covers \Adsmurai\Currency\Money::extractNumericAmount
+     * @covers \Adsmurai\Currency\Money::getAmountPlusIsoCodePattern
+     * @covers \Adsmurai\Currency\Money::getAmountPlusSymbolPattern
      */
+    #[DataProvider('invalidParamsProvider')]
     public function test_with_invalid_params(string $amount, Currency $currencyType): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Currency/GetAmountAsFractionalUnitsTests.php
+++ b/tests/Currency/GetAmountAsFractionalUnitsTests.php
@@ -6,14 +6,15 @@ namespace Adsmurai\Currency\Tests\Currency;
 
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\Money;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class GetAmountAsFractionalUnitsTests extends TestCase
 {
     /**
-     * @dataProvider stringParamsProvider
-     * @covers       \Adsmurai\Currency\Money::getAmountAsFractionalUnits
+     * @covers \Adsmurai\Currency\Money::getAmountAsFractionalUnits
      */
+    #[DataProvider('stringParamsProvider')]
     public function test_from_string(string $amount, Currency $currencyType, int $numFractionalUnits): void
     {
         $currency = Money::fromString($amount, $currencyType);
@@ -21,9 +22,9 @@ class GetAmountAsFractionalUnitsTests extends TestCase
     }
 
     /**
-     * @dataProvider floatParamsProvider
-     * @covers       \Adsmurai\Currency\Money::getAmountAsFractionalUnits
+     * @covers \Adsmurai\Currency\Money::getAmountAsFractionalUnits
      */
+    #[DataProvider('floatParamsProvider')]
     public function test_from_float(float $amount, Currency $currencyType, int $numFractionalUnits): void
     {
         $currency = Money::fromFloat($amount, $currencyType);
@@ -31,9 +32,9 @@ class GetAmountAsFractionalUnitsTests extends TestCase
     }
 
     /**
-     * @dataProvider fractionalUnitsProvider
-     * @covers       \Adsmurai\Currency\Money::getAmountAsFractionalUnits
+     * @covers \Adsmurai\Currency\Money::getAmountAsFractionalUnits
      */
+    #[DataProvider('fractionalUnitsProvider')]
     public function test_from_fractional_units(Currency $currencyType, int $numFractionalUnits): void
     {
         $currency = Money::fromFractionalUnits($numFractionalUnits, $currencyType);
@@ -50,6 +51,11 @@ class GetAmountAsFractionalUnitsTests extends TestCase
         yield ['100', CurrencyTypeMocks::getNDecimalDigitsCurrencyType(3), 100000];
         yield ['0.01', CurrencyTypeMocks::getNDecimalDigitsCurrencyType(3), 10];
         yield ['12345678.50', CurrencyTypeMocks::getNDecimalDigitsCurrencyType(3), 12345678500];
+        // Zero decimal currencies (e.g., CLP) with decimal values should truncate
+        yield ['1000', CurrencyTypeMocks::getNDecimalDigitsCurrencyType(0), 1000];
+        yield ['1000.5', CurrencyTypeMocks::getNDecimalDigitsCurrencyType(0), 1000];
+        yield ['1000.9', CurrencyTypeMocks::getNDecimalDigitsCurrencyType(0), 1000];
+        yield ['999.99', CurrencyTypeMocks::getNDecimalDigitsCurrencyType(0), 999];
     }
 
     public static function floatParamsProvider(): \Iterator
@@ -62,6 +68,11 @@ class GetAmountAsFractionalUnitsTests extends TestCase
         yield [100, CurrencyTypeMocks::getNDecimalDigitsCurrencyType(3), 100000];
         yield [0.01, CurrencyTypeMocks::getNDecimalDigitsCurrencyType(3), 10];
         yield [12345678.50, CurrencyTypeMocks::getNDecimalDigitsCurrencyType(3), 12345678500];
+        // Zero decimal currencies (e.g., CLP) with decimal values should truncate
+        yield [1000.0, CurrencyTypeMocks::getNDecimalDigitsCurrencyType(0), 1000];
+        yield [1000.5, CurrencyTypeMocks::getNDecimalDigitsCurrencyType(0), 1000];
+        yield [1000.9, CurrencyTypeMocks::getNDecimalDigitsCurrencyType(0), 1000];
+        yield [999.99, CurrencyTypeMocks::getNDecimalDigitsCurrencyType(0), 999];
     }
 
     public static function fractionalUnitsProvider(): \Iterator

--- a/tests/CurrencyFactoryTests.php
+++ b/tests/CurrencyFactoryTests.php
@@ -8,7 +8,7 @@ use Adsmurai\Currency\Contracts\Money;
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\MoneyFactory;
 use Adsmurai\Currency\CurrencyFactory;
-use Litipk\BigNumbers\Decimal;
+use Brick\Math\BigDecimal;
 use PHPUnit\Framework\TestCase;
 
 class CurrencyFactoryTests extends TestCase
@@ -68,7 +68,7 @@ class CurrencyFactoryTests extends TestCase
         $currencyType = $this->getCurrencyType();
         $currencyFactory = new MoneyFactory($currencyType);
 
-        $currency = $currencyFactory->buildFromDecimal(Decimal::fromFloat(1.0));
+        $currency = $currencyFactory->buildFromDecimal(BigDecimal::of(1.0));
 
         $this->assertInstanceOf(Money::class, $currency);
         $this->assertSame($currencyType, $currency->getCurrency());

--- a/tests/CurrencyTypeFactory/BuildFromISOCodeTests.php
+++ b/tests/CurrencyTypeFactory/BuildFromISOCodeTests.php
@@ -6,14 +6,15 @@ namespace Adsmurai\Currency\Tests\CurrencyTypeFactory;
 
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\CurrencyFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class BuildFromISOCodeTests extends TestCase
 {
     /**
-     * @dataProvider commonCurrenciesProvider
-     * @covers       \Adsmurai\Currency\CurrencyFactory
+     * @covers \Adsmurai\Currency\CurrencyFactory
      */
+    #[DataProvider('commonCurrenciesProvider')]
     public function test_with_common_currencies(string $ISOCode): void
     {
         /** @var array $currencyData */
@@ -38,9 +39,9 @@ class BuildFromISOCodeTests extends TestCase
     }
 
     /**
-     * @dataProvider commonCurrenciesProvider
-     * @covers       \Adsmurai\Currency\CurrencyFactory
+     * @covers \Adsmurai\Currency\CurrencyFactory
      */
+    #[DataProvider('commonCurrenciesProvider')]
     public function test_that_there_are_no_multiple_instances_for_same_currency_type(string $ISOCode): void
     {
         $currencyTypeFactory = CurrencyFactory::fromDataPath();

--- a/tests/CurrencyTypeFactory/FromDataArrayTests.php
+++ b/tests/CurrencyTypeFactory/FromDataArrayTests.php
@@ -6,6 +6,7 @@ namespace Adsmurai\Currency\Tests\CurrencyTypeFactory;
 
 use Adsmurai\Currency\Contracts\Currency;
 use Adsmurai\Currency\CurrencyFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FromDataArrayTests extends TestCase
@@ -46,10 +47,10 @@ class FromDataArrayTests extends TestCase
     }
 
     /**
-     * @dataProvider missingCurrencyInfoProvider
-     * @covers       \Adsmurai\Currency\CurrencyFactory::fromDataArray
-     * @covers       \Adsmurai\Currency\CurrencyFactory::validateCurrenciesData
+     * @covers \Adsmurai\Currency\CurrencyFactory::fromDataArray
+     * @covers \Adsmurai\Currency\CurrencyFactory::validateCurrenciesData
      */
+    #[DataProvider('missingCurrencyInfoProvider')]
     public function test_with_missing_currency_data(array $incompleteCurrencyInfo): void
     {
         $this->expectException(\Adsmurai\Currency\Errors\InvalidCurrenciesDataError::class);
@@ -58,10 +59,10 @@ class FromDataArrayTests extends TestCase
     }
 
     /**
-     * @dataProvider incorrectlyTypedCurrencyInfoProvider
-     * @covers       \Adsmurai\Currency\CurrencyFactory::fromDataArray
-     * @covers       \Adsmurai\Currency\CurrencyFactory::validateCurrenciesData
+     * @covers \Adsmurai\Currency\CurrencyFactory::fromDataArray
+     * @covers \Adsmurai\Currency\CurrencyFactory::validateCurrenciesData
      */
+    #[DataProvider('incorrectlyTypedCurrencyInfoProvider')]
     public function test_with_incorrectly_typed_currency_data(array $invalidCurrencyInfo): void
     {
         $this->expectException(\Adsmurai\Currency\Errors\InvalidCurrenciesDataError::class);


### PR DESCRIPTION
In order to update to PHPUnit12 and php 8.4, we need to change `"litipk/php-bignumbers": "^0.8" to "brick/math": "^0.14"`